### PR TITLE
Add filters to override local govts collection and local govt fields

### DIFF
--- a/all-countries-counties-for-wc.php
+++ b/all-countries-counties-for-wc.php
@@ -62,6 +62,7 @@ if ( ! class_exists( 'WC_All_Country_Counties' ) ) :
                     add_action( 'woocommerce_admin_order_data_after_billing_address', array($this, 'wc_billing_local_government_checkout_field_display_admin_order_meta'), 10, 1 );
                     add_action( 'woocommerce_admin_order_data_after_shipping_address', array($this, 'wc_shipping_local_government_checkout_field_display_admin_order_meta'), 10, 1 );
                     add_filter( 'woocommerce_cart_shipping_packages', array($this,'wc_add_local_government_to_cart_shipping_packages') );
+                    add_filter( 'woocommerce_checkout_update_customer_data', array( $this, 'wc_update_customer_data' ) );
                 }
             } else {
                 // throw an admin error if you like
@@ -177,6 +178,29 @@ if ( ! class_exists( 'WC_All_Country_Counties' ) ) :
         }
 
         /**
+         * Callback to update logged in customer's data
+         * Hooks to 'woocommerce_checkout_update_customer_data' filter
+         *
+         * @param  bool $should_update
+         * @param  object $checkout
+         */
+        public function wc_update_customer_data($should_update, $checkout) {
+            if ( ! empty( $_POST['billing_local_government'] ) ) {
+                $this->_update_customer( 'billing_local_government', sanitize_text_field( $_POST['billing_local_government'] ) );
+            }
+
+            if ( ! empty( $_POST['shipping_local_government'] ) ) {
+                $this->_update_customer( 'shipping_local_government', sanitize_text_field( $_POST['shipping_local_government'] ) );
+            }else {
+                if ( ! empty( $_POST['billing_local_government'] ) ) {
+                    $this->_update_customer( 'billing_local_government', sanitize_text_field( $_POST['billing_local_government'] ) );
+                }
+            }
+
+            return $should_update;
+        }
+
+        /**
          * Billing Local Government fields admin order details display
          */
         public function wc_billing_local_government_checkout_field_display_admin_order_meta($order) {
@@ -274,6 +298,18 @@ if ( ! class_exists( 'WC_All_Country_Counties' ) ) :
          */
         public function outputLastError() {
             $this->outputNotice( $this->error, false );
+        }
+
+        /**
+         * Update logged in customer's data
+         *
+         * @param  string   $meta_key   Key of the data to add
+         * @param  mixed    $meta_value      Value to be added
+         */
+        private function _update_customer($meta_key, $meta_value) {
+            if ( $checkout->customer_id ) {
+                WC()->customer[ $meta_key ] = $meta_value;
+            }
         }
 
     }

--- a/all-countries-counties-for-wc.php
+++ b/all-countries-counties-for-wc.php
@@ -108,7 +108,7 @@ if ( ! class_exists( 'WC_All_Country_Counties' ) ) :
                 }
             }
 
-            return $local_governments;
+            return apply_filters( 'wc_add_counties_local_government', $local_governments );
         }
 
         /**
@@ -141,7 +141,7 @@ if ( ! class_exists( 'WC_All_Country_Counties' ) ) :
                 )
             );
 
-            return $fields;
+            return apply_filters( 'wc_add_local_government_fields', $fields );
         }
 
         /**

--- a/local-governments/NG/LA.php
+++ b/local-governments/NG/LA.php
@@ -14,7 +14,8 @@ $local_governments ['NG']['LA' ] =
         'Alimosho' => __( 'Alimosho', 'woocommerce' ),
         'Amuwo Odofin' => __( 'Amuwo Odofin', 'woocommerce' ),
         'Apapa' => __( 'Apapa', 'woocommerce' ),
-        'Epe' => __( 'Epe', 'woocommerce' ),
+        '*Badagry' => __( 'Badagry', 'woocommerce' ),
+        '*Epe' => __( 'Epe', 'woocommerce' ),
         'Eti Osa' => __( 'Eti Osa', 'woocommerce' ),
         'Ibeju/lekki' => __( 'Ibeju/lekki', 'woocommerce' ),
         'Ifako Ijaiye' => __( 'Ifako Ijaiye', 'woocommerce' ),
@@ -28,5 +29,4 @@ $local_governments ['NG']['LA' ] =
         'Oshodi/isolo' => __( 'Oshodi/isolo', 'woocommerce' ),
         'Shomolu' => __( 'Shomolu', 'woocommerce' ),
         'Surulere' => __( 'Surulere', 'woocommerce' ),
-        'Badagry' => __( 'Badagry', 'woocommerce' )
     ];

--- a/public/js/checkout-fields.js
+++ b/public/js/checkout-fields.js
@@ -4,10 +4,15 @@
 
 var country_with_local_governments = JSON.parse(checkout_fields_data.country_with_local_governments);
 var local_government_for_states_country = JSON.parse(checkout_fields_data.local_government_for_states_country);
+var isCart = location.pathname.indexOf('cart') > -1;
 var billing_select = "select#billing_local_government";
 var billing_field = "#billing_local_government_field";
 var shipping_select = "select#shipping_local_government";
 var shipping_field = "#shipping_local_government_field";
+var billing_country = "select#billing_country";
+var billing_state = "select#billing_state";
+var shipping_country = isCart ? "select#calc_shipping_country" : "select#shipping_country";
+var shipping_state = isCart ? "select#calc_shipping_state" : "select#shipping_state";
 
 function update_select(selected_country, selected_state, select_selector, field_selector, default_value) {
     var select = jQuery(select_selector);
@@ -33,22 +38,22 @@ function update_select(selected_country, selected_state, select_selector, field_
     }
 }
 
-if(jQuery("select#billing_state").val() != "") {
-    update_select(jQuery("select#billing_country").val(), jQuery("select#billing_state").val(), billing_select, billing_field, "");
+if(jQuery(billing_state).val() != "") {
+    update_select(jQuery(billing_country).val(), jQuery(billing_state).val(), billing_select, billing_field, "")
 }
 
-if(jQuery("select#shipping_state").val() != "") {
-    update_select(jQuery("select#shipping_country").val(), jQuery("select#shipping_state").val(), shipping_select, shipping_field, "");
+if(jQuery(shipping_state).val() != "") {
+    update_select(jQuery(shipping_country).val(), jQuery(shipping_state).val(), shipping_select, shipping_field, "")
 }
 
-jQuery("select#billing_state").on("change", function(){
-    var billing_selected_country = jQuery("select#billing_country").val();
-    var billing_selected_state = jQuery("select#billing_state").val();
-    update_select(billing_selected_country, billing_selected_state, billing_select, billing_field);
+jQuery(billing_state).on("change", function(){
+    var billing_selected_country = jQuery(billing_country).val();
+    var billing_selected_state = jQuery(billing_state).val();
+    update_select(billing_selected_country, billing_selected_state, billing_select, billing_field)
 });
 
-jQuery("body").on("change", "select#shipping_state", function(){
-    var shipping_selected_country = jQuery("select#shipping_country").val();
-    var shipping_selected_state = jQuery("select#shipping_state").val();
-    update_select(shipping_selected_country, shipping_selected_state, shipping_select, shipping_field);
+jQuery("body").on("change", shipping_state, function(){
+    var shipping_selected_country = jQuery(shipping_country).val();
+    var shipping_selected_state = jQuery(shipping_state).val();
+    update_select(shipping_selected_country, shipping_selected_state, shipping_select, shipping_field)
 });

--- a/public/js/checkout-fields.js
+++ b/public/js/checkout-fields.js
@@ -4,12 +4,15 @@
 
 var country_with_local_governments = JSON.parse(checkout_fields_data.country_with_local_governments);
 var local_government_for_states_country = JSON.parse(checkout_fields_data.local_government_for_states_country);
-var billing_select = jQuery("select#billing_local_government");
-var billing_field = jQuery("#billing_local_government_field");
-var shipping_select = jQuery("select#shipping_local_government");
-var shipping_field = jQuery("#shipping_local_government_field");
+var billing_select = "select#billing_local_government";
+var billing_field = "#billing_local_government_field";
+var shipping_select = "select#shipping_local_government";
+var shipping_field = "#shipping_local_government_field";
 
-function update_select(selected_country, selected_state, select, field, default_value) {
+function update_select(selected_country, selected_state, select_selector, field_selector, default_value) {
+    var select = jQuery(select_selector);
+    var field = jQuery(field_selector);
+
     if (selected_country != "" && selected_state != "" && jQuery.inArray( selected_country, country_with_local_governments ) >= 0 && typeof local_government_for_states_country[selected_country][selected_state] != "undefined") {
         select.empty();
         jQuery.each(local_government_for_states_country[selected_country][selected_state], function(key,value) {
@@ -31,21 +34,21 @@ function update_select(selected_country, selected_state, select, field, default_
 }
 
 if(jQuery("select#billing_state").val() != "") {
-    update_select(jQuery("select#billing_country").val(), jQuery("select#billing_state").val(), billing_select, billing_field, "")
+    update_select(jQuery("select#billing_country").val(), jQuery("select#billing_state").val(), billing_select, billing_field, "");
 }
 
 if(jQuery("select#shipping_state").val() != "") {
-    update_select(jQuery("select#shipping_country").val(), jQuery("select#shipping_state").val(), shipping_select, shipping_field, "")
+    update_select(jQuery("select#shipping_country").val(), jQuery("select#shipping_state").val(), shipping_select, shipping_field, "");
 }
 
 jQuery("select#billing_state").on("change", function(){
     var billing_selected_country = jQuery("select#billing_country").val();
     var billing_selected_state = jQuery("select#billing_state").val();
-    update_select(billing_selected_country, billing_selected_state, billing_select, billing_field)
+    update_select(billing_selected_country, billing_selected_state, billing_select, billing_field);
 });
 
-jQuery("select#shipping_state").on("change", function(){
+jQuery("body").on("change", "select#shipping_state", function(){
     var shipping_selected_country = jQuery("select#shipping_country").val();
     var shipping_selected_state = jQuery("select#shipping_state").val();
-    update_select(shipping_selected_country, shipping_selected_state, shipping_select, shipping_field)
+    update_select(shipping_selected_country, shipping_selected_state, shipping_select, shipping_field);
 });


### PR DESCRIPTION

I thought it would be nice to have a way one can extend or override some parts of the plugin in a theme's functions.php.

A use case is when I needed to use the 36 Local Council Development Areas in Lagos instead of the 20 Local Governments. All I had to do was to hook to the `wc_add_counties_local_government` filter and override the `$local_governments` variable for LA returned by `wc_add_counties_local_government()`.

```
add_filter( 'wc_add_counties_local_government', 'my_custom_lga' );

function my_custom_lga( $local_governments ) { 
  $local_governments['NG']['LA'] = my_custom_lga_array();

  return $local_governments;
}
```